### PR TITLE
Hotfix #32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,14 @@ python:
   - "3.6"
 env:
   - SDG_REF="master" API_VERSION=""
-  - SDG_REF="develop" API_VERSION="dev"
+#  - SDG_REF="develop" API_VERSION="dev"
+#  - SDG_REF="hotfix/25" API_VERSION="test"
 matrix:
   allow_failures:
     - env: SDG_REF="develop"
 sudo: false
+git:
+  depth: false
 
 branches:
   only:


### PR DESCRIPTION
Fixes issue whereby the "last updated" field was wrong because we only clone 50 commits on Travis. This switches off the depth flag on the git clone.