### PR TITLE
Hide "indicator display order" in Global metadata

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -35,11 +35,6 @@ prose:
             element: hidden
             label: "Indicator number"
             scope: global
-      - name: "indicator_sort_order"
-        field:
-            element: text
-            label: "Indicator display order (within Goal page)"
-            scope: global
       - name: "target"
         field:
             element: text
@@ -176,6 +171,11 @@ prose:
             label: Show the map when GeoCodes are present?
             help: If this box is checked then the prescence of a GeoCode field will trigger a map
             value: false
+            scope: data
+      - name: "indicator_sort_order"
+        field:
+            element: text
+            label: "Indicator display order (within Goal page)"
             scope: data
       ######### Chart Info #########
       - name: "graph_type"


### PR DESCRIPTION
I don't believe we want the "indicator display order" to display in the "Global Metadata" tab. This moves it to the "data" scope which should keep it from displaying.