### PR TITLE
Fix indicator_sort_order so that they are non-numreic

### DIFF
--- a/meta/1-1-1.md
+++ b/meta/1-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: 01-01-01
 permalink: /1-1-1/
 sdg_goal: '1'
 title: >-

--- a/meta/1-2-1.md
+++ b/meta/1-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 01-02-01
 permalink: /1-2-1/
 sdg_goal: '1'
 title: >-

--- a/meta/1-2-2.md
+++ b/meta/1-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.2.2
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 01-02-02
 permalink: /1-2-2/
 sdg_goal: '1'
 title: >-

--- a/meta/1-3-1.md
+++ b/meta/1-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.3.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 01-03-01
 permalink: /1-3-1/
 sdg_goal: '1'
 title: >-

--- a/meta/1-4-1.md
+++ b/meta/1-4-1.md
@@ -3,7 +3,7 @@ indicator: 1.4.1
 layout: indicator
 permalink: /1-4-1/
 sdg_goal: '1'
-indicator_sort_order: '0050'
+indicator_sort_order: 01-04-01
 title: Proportion of population living in households with access to basic services
 graph_type: line
 un_designated_tier: '3'

--- a/meta/1-4-2.md
+++ b/meta/1-4-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.4.2
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: 01-04-02
 permalink: /1-4-2/
 sdg_goal: '1'
 title: >-

--- a/meta/1-5-1.md
+++ b/meta/1-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.5.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: 01-05-01
 permalink: /1-5-1/
 sdg_goal: '1'
 title: >-

--- a/meta/1-5-2.md
+++ b/meta/1-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.5.2
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 01-05-02
 permalink: /1-5-2/
 sdg_goal: '1'
 title: >-

--- a/meta/1-5-3.md
+++ b/meta/1-5-3.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.5.3
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: 01-05-03
 permalink: /1-5-3/
 sdg_goal: '1'
 title: >-

--- a/meta/1-5-4.md
+++ b/meta/1-5-4.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.5.4
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: 01-05-04
 permalink: /1-5-4/
 sdg_goal: '1'
 graph_type: line

--- a/meta/1-a-1.md
+++ b/meta/1-a-1.md
@@ -3,7 +3,7 @@ indicator: 1.a.1
 layout: indicator
 permalink: /1-a-1/
 sdg_goal: '1'
-indicator_sort_order: '0110'
+indicator_sort_order: 01-aa-01
 title: >-
   Proportion of domestically generated resources allocated by the government
   directly to poverty reduction programmes

--- a/meta/1-a-2.md
+++ b/meta/1-a-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 1.a.2
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: 01-aa-02
 permalink: /1-a-2/
 sdg_goal: '1'
 title: >-

--- a/meta/1-a-3.md
+++ b/meta/1-a-3.md
@@ -3,7 +3,7 @@ indicator: 1.a.3
 layout: indicator
 permalink: /1-a-3/
 sdg_goal: '1'
-indicator_sort_order: '0130'
+indicator_sort_order: 01-aa-03
 graph_type: line
 reporting_status: inprogress
 title: >-

--- a/meta/1-b-1.md
+++ b/meta/1-b-1.md
@@ -3,7 +3,7 @@ indicator: 1.b.1
 layout: indicator
 permalink: /1-b-1/
 sdg_goal: '1'
-indicator_sort_order: '0140'
+indicator_sort_order: 01-bb-01
 title: >-
   Proportion of government recurrent and capital spending to sectors that
   disproportionately benefit women, the poor and vulnerable groups

--- a/meta/10-1-1.md
+++ b/meta/10-1-1.md
@@ -3,7 +3,7 @@ layout: indicator
 sdg_goal: '10'
 target_id: '10.1'
 permalink: /10-1-1/
-indicator_sort_order: 0010
+indicator_sort_order: 10-01-01
 published: true
 target: 10.1 By 2030, progressively achieve and sustain income growth of the bottom 40 per cent of the population at a rate higher than the national average
 indicator: 10.1.1

--- a/meta/10-2-1.md
+++ b/meta/10-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 10-02-01
 permalink: /10-2-1/
 sdg_goal: '10'
 title: >-

--- a/meta/10-3-1.md
+++ b/meta/10-3-1.md
@@ -3,7 +3,7 @@ indicator: 10.3.1
 layout: indicator
 permalink: /10-3-1/
 sdg_goal: '10'
-indicator_sort_order: '0030'
+indicator_sort_order: 10-03-01
 title: >-
   Proportion of population reporting having personally felt discriminated
   against or harassed in the previous 12 months on the basis of a ground of

--- a/meta/10-4-1.md
+++ b/meta/10-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.4.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 10-04-01
 permalink: /10-4-1/
 sdg_goal: '10'
 title: 'Labour share of GDP, comprising wages and social protection transfers'

--- a/meta/10-5-1.md
+++ b/meta/10-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.5.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 10-05-01
 permalink: /10-5-1/
 sdg_goal: '10'
 title: Financial Soundness Indicators

--- a/meta/10-6-1.md
+++ b/meta/10-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.6.1
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: 10-06-01
 permalink: /10-6-1/
 sdg_goal: '10'
 graph_type: line

--- a/meta/10-7-1.md
+++ b/meta/10-7-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.7.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: 10-07-01
 permalink: /10-7-1/
 sdg_goal: '10'
 title: >-

--- a/meta/10-7-2.md
+++ b/meta/10-7-2.md
@@ -3,7 +3,7 @@ indicator: 10.7.2
 layout: indicator
 permalink: /10-7-2/
 sdg_goal: '10'
-indicator_sort_order: 0080
+indicator_sort_order: 10-07-02
 title: Number of countries that have implemented well-managed migration policies
 graph_type: line
 un_designated_tier: '3'

--- a/meta/10-a-1.md
+++ b/meta/10-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.a.1
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: 10-aa-01
 permalink: /10-a-1/
 sdg_goal: '10'
 title: >-

--- a/meta/10-b-1.md
+++ b/meta/10-b-1.md
@@ -3,7 +3,7 @@ indicator: 10.b.1
 layout: indicator
 permalink: /10-b-1/
 sdg_goal: '10'
-indicator_sort_order: '0100'
+indicator_sort_order: 10-bb-01
 title: >-
   Total resource flows for development, by recipient and donor countries and
   type of flow (e.g. official development assistance, foreign direct investment

--- a/meta/10-c-1.md
+++ b/meta/10-c-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 10.c.1
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: 10-cc-01
 permalink: /10-c-1/
 sdg_goal: '10'
 title: Remittance costs as a proportion of the amount remitted

--- a/meta/11-1-1.md
+++ b/meta/11-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: 11-01-01
 permalink: /11-1-1/
 sdg_goal: '11'
 title: >-

--- a/meta/11-2-1.md
+++ b/meta/11-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 11-02-01
 permalink: /11-2-1/
 sdg_goal: '11'
 title: >-

--- a/meta/11-3-1.md
+++ b/meta/11-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.3.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 11-03-01
 permalink: /11-3-1/
 sdg_goal: '11'
 title: Ratio of land consumption rate to population growth rate

--- a/meta/11-3-2.md
+++ b/meta/11-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.3.2
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 11-03-02
 permalink: /11-3-2/
 sdg_goal: '11'
 title: >-

--- a/meta/11-4-1.md
+++ b/meta/11-4-1.md
@@ -3,7 +3,7 @@ indicator: 11.4.1
 layout: indicator
 permalink: /11-4-1/
 sdg_goal: '11'
-indicator_sort_order: '0050'
+indicator_sort_order: 11-04-01
 title: >-
   Total expenditure (public and private) per capita spent on the preservation,
   protection and conservation of all cultural and natural heritage, by type of

--- a/meta/11-5-1.md
+++ b/meta/11-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.5.1
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: 11-05-01
 permalink: /11-5-1/
 sdg_goal: '11'
 title: >-

--- a/meta/11-5-2.md
+++ b/meta/11-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.5.2
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: 11-05-02
 permalink: /11-5-2/
 sdg_goal: '11'
 title: >-

--- a/meta/11-6-1.md
+++ b/meta/11-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.6.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 11-06-01
 permalink: /11-6-1/
 sdg_goal: '11'
 title: >-

--- a/meta/11-6-2.md
+++ b/meta/11-6-2.md
@@ -3,7 +3,7 @@ indicator: 11.6.2
 layout: indicator
 permalink: /11-6-2/
 sdg_goal: '11'
-indicator_sort_order: 0090
+indicator_sort_order: 11-06-02
 title: >-
   Annual mean levels of fine particulate matter (e.g. PM2.5 and PM10) in cities
   (population weighted)

--- a/meta/11-7-1.md
+++ b/meta/11-7-1.md
@@ -3,7 +3,7 @@ indicator: 11.7.1
 layout: indicator
 permalink: /11-7-1/
 sdg_goal: '11'
-indicator_sort_order: '0100'
+indicator_sort_order: 11-07-01
 title: >-
   Average share of the built-up area of cities that is open space for public use
   for all, by sex, age and persons with disabilities

--- a/meta/11-7-2.md
+++ b/meta/11-7-2.md
@@ -3,7 +3,7 @@ indicator: 11.7.2
 layout: indicator
 permalink: /11-7-2/
 sdg_goal: '11'
-indicator_sort_order: '0110'
+indicator_sort_order: 11-07-02
 title: >-
   Proportion of persons victim of physical or sexual harassment, by sex, age,
   disability status and place of occurrence, in the previous 12 months

--- a/meta/11-a-1.md
+++ b/meta/11-a-1.md
@@ -3,7 +3,7 @@ indicator: 11.a.1
 layout: indicator
 permalink: /11-a-1/
 sdg_goal: '11'
-indicator_sort_order: '0120'
+indicator_sort_order: 11-aa-01
 title: >-
   Proportion of population living in cities that implement urban and regional
   development plans integrating population projections and resource needs, by

--- a/meta/11-b-1.md
+++ b/meta/11-b-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.b.1
 layout: indicator
-indicator_sort_order: '0130'
+indicator_sort_order: 11-bb-01
 permalink: /11-b-1/
 sdg_goal: '11'
 title: >-

--- a/meta/11-b-2.md
+++ b/meta/11-b-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 11.b.2
 layout: indicator
-indicator_sort_order: '0140'
+indicator_sort_order: 11-bb-02
 permalink: /11-b-2/
 sdg_goal: '11'
 title: >-

--- a/meta/11-c-1.md
+++ b/meta/11-c-1.md
@@ -3,7 +3,7 @@ indicator: 11.c.1
 layout: indicator
 permalink: /11-c-1/
 sdg_goal: '11'
-indicator_sort_order: '0150'
+indicator_sort_order: 11-cc-01
 title: >-
   Proportion of financial support to the least developed countries that is
   allocated to the construction and retrofitting of sustainable, resilient and

--- a/meta/12-1-1.md
+++ b/meta/12-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 12.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: 12-01-01
 permalink: /12-1-1/
 sdg_goal: '12'
 title: >-

--- a/meta/12-2-1.md
+++ b/meta/12-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 12.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 12-02-01
 permalink: /12-2-1/
 sdg_goal: '12'
 title: >-

--- a/meta/12-2-2.md
+++ b/meta/12-2-2.md
@@ -3,7 +3,7 @@ indicator: 12.2.2
 layout: indicator
 permalink: /12-2-2/
 sdg_goal: '12'
-indicator_sort_order: '0030'
+indicator_sort_order: 12-02-02
 title: >-
   Domestic material consumption, domestic material consumption per capita, and
   domestic material consumption per GDP

--- a/meta/12-3-1.md
+++ b/meta/12-3-1.md
@@ -3,7 +3,7 @@ indicator: 12.3.1
 layout: indicator
 permalink: /12-3-1/
 sdg_goal: '12'
-indicator_sort_order: '0040'
+indicator_sort_order: 12-03-01
 title: Global food loss index
 graph_type: line
 un_designated_tier: '3'

--- a/meta/12-4-1.md
+++ b/meta/12-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 12.4.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 12-04-01
 permalink: /12-4-1/
 sdg_goal: '12'
 title: >-

--- a/meta/12-4-2.md
+++ b/meta/12-4-2.md
@@ -3,7 +3,7 @@ indicator: 12.4.2
 layout: indicator
 permalink: /12-4-2/
 sdg_goal: '12'
-indicator_sort_order: '0060'
+indicator_sort_order: 12-04-02
 title: >-
   Hazardous waste generated per capita and proportion of hazardous waste
   treated, by type of treatment

--- a/meta/12-5-1.md
+++ b/meta/12-5-1.md
@@ -3,7 +3,7 @@ indicator: 12.5.1
 layout: indicator
 permalink: /12-5-1/
 sdg_goal: '12'
-indicator_sort_order: '0070'
+indicator_sort_order: 12-05-01
 title: 'National recycling rate, tons of material recycled'
 graph_type: line
 un_designated_tier: '3'

--- a/meta/12-6-1.md
+++ b/meta/12-6-1.md
@@ -3,7 +3,7 @@ indicator: 12.6.1
 layout: indicator
 permalink: /12-6-1/
 sdg_goal: '12'
-indicator_sort_order: 0080
+indicator_sort_order: 12-06-01
 title: Number of companies publishing sustainability reports
 graph_type: line
 un_designated_tier: '3'

--- a/meta/12-7-1.md
+++ b/meta/12-7-1.md
@@ -3,7 +3,7 @@ indicator: 12.7.1
 layout: indicator
 permalink: /12-7-1/
 sdg_goal: '12'
-indicator_sort_order: 0090
+indicator_sort_order: 12-07-01
 title: >-
   Number of countries implementing sustainable public procurement policies and
   action plans

--- a/meta/12-8-1.md
+++ b/meta/12-8-1.md
@@ -3,7 +3,7 @@ indicator: 12.8.1
 layout: indicator
 permalink: /12-8-1/
 sdg_goal: '12'
-indicator_sort_order: '0100'
+indicator_sort_order: 12-08-01
 title: "Extent to which (i) global citizenship education and (ii) education for sustainable development (including climate change education) are mainstreamed in (a) national education policies; (b)\_curricula; (c) teacher education; and (d) student assessment"
 graph_type: line
 un_designated_tier: '3'

--- a/meta/12-a-1.md
+++ b/meta/12-a-1.md
@@ -3,7 +3,7 @@ indicator: 12.a.1
 layout: indicator
 permalink: /12-a-1/
 sdg_goal: '12'
-indicator_sort_order: '0110'
+indicator_sort_order: 12-aa-01
 title: >-
   Amount of support to developing countries on research and development for
   sustainable consumption and production and environmentally sound technologies

--- a/meta/12-b-1.md
+++ b/meta/12-b-1.md
@@ -3,7 +3,7 @@ indicator: 12.b.1
 layout: indicator
 permalink: /12-b-1/
 sdg_goal: '12'
-indicator_sort_order: '0120'
+indicator_sort_order: 12-bb-01
 title: >-
   Number of sustainable tourism strategies or policies and implemented action
   plans with agreed monitoring and evaluation tools

--- a/meta/12-c-1.md
+++ b/meta/12-c-1.md
@@ -3,7 +3,7 @@ indicator: 12.c.1
 layout: indicator
 permalink: /12-c-1/
 sdg_goal: '12'
-indicator_sort_order: '0130'
+indicator_sort_order: 12-cc-01
 title: >-
   Amount of fossil-fuel subsidies per unit of GDP (production and consumption)
   and as a proportion of total national expenditure on fossil fuels

--- a/meta/13-1-1.md
+++ b/meta/13-1-1.md
@@ -3,7 +3,7 @@ indicator: 13.1.1
 layout: indicator
 permalink: /13-1-1/
 sdg_goal: '13'
-indicator_sort_order: '0010'
+indicator_sort_order: 13-01-01
 title: >-
   Number of deaths, missing persons and directly affected persons
   attributed to disasters per 100,000 population

--- a/meta/13-1-2.md
+++ b/meta/13-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 13.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 13-01-02
 permalink: /13-1-2/
 sdg_goal: '13'
 title: >-

--- a/meta/13-1-3.md
+++ b/meta/13-1-3.md
@@ -1,7 +1,7 @@
 ---
 indicator: 13.1.3
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 13-01-03
 permalink: /13-1-3/
 sdg_goal: '13'
 graph_type: line

--- a/meta/13-2-1.md
+++ b/meta/13-2-1.md
@@ -3,7 +3,7 @@ indicator: 13.2.1
 layout: indicator
 permalink: /13-2-1/
 sdg_goal: '13'
-indicator_sort_order: '0040'
+indicator_sort_order: 13-02-01
 title: >-
   Number of countries that have communicated the establishment or
   operationalization of an integrated policy/strategy/plan which increases their

--- a/meta/13-3-1.md
+++ b/meta/13-3-1.md
@@ -3,7 +3,7 @@ indicator: 13.3.1
 layout: indicator
 permalink: /13-3-1/
 sdg_goal: '13'
-indicator_sort_order: '0050'
+indicator_sort_order: 13-03-01
 title: >-
   Number of countries that have integrated mitigation, adaptation, impact
   reduction and early warning into primary, secondary and tertiary curricula

--- a/meta/13-3-2.md
+++ b/meta/13-3-2.md
@@ -3,7 +3,7 @@ indicator: 13.3.2
 layout: indicator
 permalink: /13-3-2/
 sdg_goal: '13'
-indicator_sort_order: '0060'
+indicator_sort_order: 13-03-02
 title: >-
   Number of countries that have communicated the strengthening of institutional,
   systemic and individual capacity-building to implement adaptation, mitigation

--- a/meta/13-a-1.md
+++ b/meta/13-a-1.md
@@ -3,7 +3,7 @@ indicator: 13.a.1
 layout: indicator
 permalink: /13-a-1/
 sdg_goal: '13'
-indicator_sort_order: '0070'
+indicator_sort_order: 13-aa-01
 title: "Mobilized amount of United States dollars per year between 2020 and 2025 accountable towards the $100\_billion commitment"
 graph_type: line
 un_designated_tier: '3'

--- a/meta/13-b-1.md
+++ b/meta/13-b-1.md
@@ -3,7 +3,7 @@ indicator: 13.b.1
 layout: indicator
 permalink: /13-b-1/
 sdg_goal: '13'
-indicator_sort_order: 0080
+indicator_sort_order: 13-bb-01
 title: >-
   Number of least developed countries and small island developing States that
   are receiving specialized support, and amount of support, including finance,

--- a/meta/14-1-1.md
+++ b/meta/14-1-1.md
@@ -3,7 +3,7 @@ indicator: 14.1.1
 layout: indicator
 permalink: /14-1-1/
 sdg_goal: '14'
-indicator_sort_order: '0010'
+indicator_sort_order: 14-01-01
 title: Index of coastal eutrophication and floating plastic debris density
 un_designated_tier: '3'
 un_custodian_agency: UNEP

--- a/meta/14-2-1.md
+++ b/meta/14-2-1.md
@@ -3,7 +3,7 @@ indicator: 14.2.1
 layout: indicator
 permalink: /14-2-1/
 sdg_goal: '14'
-indicator_sort_order: '0020'
+indicator_sort_order: 14-02-01
 title: >-
   Proportion of national exclusive economic zones managed using ecosystem-based
   approaches

--- a/meta/14-3-1.md
+++ b/meta/14-3-1.md
@@ -3,7 +3,7 @@ indicator: 14.3.1
 layout: indicator
 permalink: /14-3-1/
 sdg_goal: '14'
-indicator_sort_order: '0030'
+indicator_sort_order: 14-03-01
 title: >-
   Average marine acidity (pH) measured at agreed suite of representative
   sampling stations

--- a/meta/14-4-1.md
+++ b/meta/14-4-1.md
@@ -3,7 +3,7 @@ indicator: 14.4.1
 layout: indicator
 permalink: /14-4-1/
 sdg_goal: '14'
-indicator_sort_order: '0040'
+indicator_sort_order: 14-04-01
 title: Proportion of fish stocks within biologically sustainable levels
 target_id: '14.4'
 target: >-

--- a/meta/14-5-1.md
+++ b/meta/14-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 14.5.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 14-05-01
 permalink: /14-5-1/
 sdg_goal: '14'
 title: Coverage of protected areas in relation to marine areas

--- a/meta/14-6-1.md
+++ b/meta/14-6-1.md
@@ -3,7 +3,7 @@ indicator: 14.6.1
 layout: indicator
 permalink: /14-6-1/
 sdg_goal: '14'
-indicator_sort_order: '0060'
+indicator_sort_order: 14-06-01
 title: >-
   Progress by countries in the degree of implementation of international
   instruments aiming to combat illegal, unreported and unregulated fishing

--- a/meta/14-7-1.md
+++ b/meta/14-7-1.md
@@ -3,7 +3,7 @@ indicator: 14.7.1
 layout: indicator
 permalink: /14-7-1/
 sdg_goal: '14'
-indicator_sort_order: '0070'
+indicator_sort_order: 14-07-01
 title: >-
   Sustainable fisheries as a proportion of GDP in small island developing
   States, least developed countries and all countries

--- a/meta/14-a-1.md
+++ b/meta/14-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 14.a.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 14-aa-01
 permalink: /14-a-1/
 sdg_goal: '14'
 title: >-

--- a/meta/14-b-1.md
+++ b/meta/14-b-1.md
@@ -3,7 +3,7 @@ indicator: 14.b.1
 layout: indicator
 permalink: /14-b-1/
 sdg_goal: '14'
-indicator_sort_order: 0090
+indicator_sort_order: 14-bb-01
 title: >-
   Progress by countries in the degree of application of a
   legal/regulatory/policy/institutional framework which recognizes and protects

--- a/meta/14-c-1.md
+++ b/meta/14-c-1.md
@@ -3,7 +3,7 @@ indicator: 14.c.1
 layout: indicator
 permalink: /14-c-1/
 sdg_goal: '14'
-indicator_sort_order: '0100'
+indicator_sort_order: 14-cc-01
 title: >-
   Number of countries making progress in ratifying, accepting and implementing
   through legal, policy and institutional frameworks, ocean-related instruments

--- a/meta/15-1-1.md
+++ b/meta/15-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: 15-01-01
 permalink: /15-1-1/
 sdg_goal: '15'
 title: Forest area as a proportion of total land area

--- a/meta/15-1-2.md
+++ b/meta/15-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 15-01-02
 permalink: /15-1-2/
 sdg_goal: '15'
 title: >-

--- a/meta/15-2-1.md
+++ b/meta/15-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 15-02-01
 permalink: /15-2-1/
 sdg_goal: '15'
 title: Progress towards sustainable forest management

--- a/meta/15-3-1.md
+++ b/meta/15-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.3.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 15-03-01
 permalink: /15-3-1/
 sdg_goal: '15'
 title: Proportion of land that is degraded over total land area

--- a/meta/15-4-1.md
+++ b/meta/15-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.4.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 15-04-01
 permalink: /15-4-1/
 sdg_goal: '15'
 title: Coverage by protected areas of important sites for mountain biodiversity

--- a/meta/15-4-2.md
+++ b/meta/15-4-2.md
@@ -3,7 +3,7 @@ indicator: 15.4.2
 layout: indicator
 permalink: /15-4-2/
 sdg_goal: '15'
-indicator_sort_order: '0060'
+indicator_sort_order: 15-04-02
 title: Mountain Green Cover Index
 graph_type: bar
 un_custodian_agency: Food and Agriculture Organization (FAO)

--- a/meta/15-5-1.md
+++ b/meta/15-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.5.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: 15-05-01
 permalink: /15-5-1/
 sdg_goal: '15'
 title: Red List Index

--- a/meta/15-6-1.md
+++ b/meta/15-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.6.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 15-06-01
 permalink: /15-6-1/
 sdg_goal: '15'
 title: >-

--- a/meta/15-7-1.md
+++ b/meta/15-7-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.7.1
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: 15-07-01
 permalink: /15-7-1/
 sdg_goal: '15'
 title: Proportion of traded wildlife that was poached or illicitly trafficked

--- a/meta/15-8-1.md
+++ b/meta/15-8-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.8.1
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: 15-08-01
 permalink: /15-8-1/
 sdg_goal: '15'
 title: >-

--- a/meta/15-9-1.md
+++ b/meta/15-9-1.md
@@ -3,7 +3,7 @@ indicator: 15.9.1
 layout: indicator
 permalink: /15-9-1/
 sdg_goal: '15'
-indicator_sort_order: '0110'
+indicator_sort_order: 15-09-01
 title: >-
   Progress towards national targets established in accordance with Aichi
   Biodiversity Target 2 of the Strategic Plan for Biodiversity 2011-2020

--- a/meta/15-a-1.md
+++ b/meta/15-a-1.md
@@ -3,7 +3,7 @@ indicator: 15.a.1
 layout: indicator
 permalink: /15-a-1/
 sdg_goal: '15'
-indicator_sort_order: '0120'
+indicator_sort_order: 15-aa-01
 title: >-
   Official development assistance and public expenditure on conservation and
   sustainable use of biodiversity and ecosystems

--- a/meta/15-b-1.md
+++ b/meta/15-b-1.md
@@ -3,7 +3,7 @@ indicator: 15.b.1
 layout: indicator
 permalink: /15-b-1/
 sdg_goal: '15'
-indicator_sort_order: '0130'
+indicator_sort_order: 15-bb-01
 title: >-
   Official development assistance and public expenditure on conservation and
   sustainable use of biodiversity and ecosystems

--- a/meta/15-c-1.md
+++ b/meta/15-c-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 15.c.1
 layout: indicator
-indicator_sort_order: '0140'
+indicator_sort_order: 15-cc-01
 permalink: /15-c-1/
 sdg_goal: '15'
 title: Proportion of traded wildlife that was poached or illicitly trafficked

--- a/meta/16-1-1.md
+++ b/meta/16-1-1.md
@@ -3,7 +3,7 @@ indicator: 16.1.1
 layout: indicator
 permalink: /16-1-1/
 sdg_goal: '16'
-indicator_sort_order: '0010'
+indicator_sort_order: 16-01-01
 title: >-
   Number of victims of intentional homicide per 100,000 population, by sex and
   age

--- a/meta/16-1-2.md
+++ b/meta/16-1-2.md
@@ -3,7 +3,7 @@ indicator: 16.1.2
 layout: indicator
 permalink: /16-1-2/
 sdg_goal: '16'
-indicator_sort_order: '0020'
+indicator_sort_order: 16-01-02
 title: 'Conflict-related deaths per 100,000 population, by sex, age and cause'
 target_id: '16.1'
 target: Significantly reduce all forms of violence and related death rates everywhere

--- a/meta/16-1-3.md
+++ b/meta/16-1-3.md
@@ -4,7 +4,7 @@ layout: indicator
 permalink: /16-1-3/
 sdg_goal: '16'
 target_id: '16.1'
-indicator_sort_order: 0030
+indicator_sort_order: 16-01-03
 published: true
 target: >-
   16.1 Significantly reduce all forms of violence and related death rates

--- a/meta/16-1-4.md
+++ b/meta/16-1-4.md
@@ -3,7 +3,7 @@ layout: indicator
 sdg_goal: '16'
 target_id: '16.1'
 permalink: /16-1-4/
-indicator_sort_order: 0040
+indicator_sort_order: 16-01-04
 published: true
 target: 16.1 Significantly reduce all forms of violence and related death rates everywhere
 indicator: 16.1.4

--- a/meta/16-10-1.md
+++ b/meta/16-10-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.10.1
 layout: indicator
-indicator_sort_order: '0200'
+indicator_sort_order: 16-10-01
 permalink: /16-10-1/
 sdg_goal: '16'
 title: >-

--- a/meta/16-10-2.md
+++ b/meta/16-10-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.10.2
 layout: indicator
-indicator_sort_order: '0210'
+indicator_sort_order: 16-10-02
 permalink: /16-10-2/
 sdg_goal: '16'
 title: >-

--- a/meta/16-2-1.md
+++ b/meta/16-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.2.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 16-02-01
 permalink: /16-2-1/
 sdg_goal: '16'
 title: >-

--- a/meta/16-2-2.md
+++ b/meta/16-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.2.2
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: 16-02-02
 permalink: /16-2-2/
 sdg_goal: '16'
 title: >-

--- a/meta/16-2-3.md
+++ b/meta/16-2-3.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.2.3
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: 16-02-03
 permalink: /16-2-3/
 sdg_goal: '16'
 title: >-

--- a/meta/16-3-1.md
+++ b/meta/16-3-1.md
@@ -3,7 +3,7 @@ indicator: 16.3.1
 layout: indicator
 permalink: /16-3-1/
 sdg_goal: '16'
-indicator_sort_order: 0080
+indicator_sort_order: 16-03-01
 title: >-
   Proportion of victims of violence in the previous 12 months who reported their
   victimization to competent authorities or other officially recognized conflict

--- a/meta/16-3-2.md
+++ b/meta/16-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.3.2
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: 16-03-02
 permalink: /16-3-2/
 sdg_goal: '16'
 title: Unsentenced detainees as a proportion of overall prison population

--- a/meta/16-4-1.md
+++ b/meta/16-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.4.1
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: 16-04-01
 permalink: /16-4-1/
 sdg_goal: '16'
 title: >-

--- a/meta/16-4-2.md
+++ b/meta/16-4-2.md
@@ -3,7 +3,7 @@ indicator: 16.4.2
 layout: indicator
 permalink: /16-4-2/
 sdg_goal: '16'
-indicator_sort_order: '0110'
+indicator_sort_order: 16-04-02
 title: >-
   Proportion of seized, found or surrendered arms whose illicit origin or
   context has been traced or established by a competent authority in line with

--- a/meta/16-5-1.md
+++ b/meta/16-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.5.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: 16-05-01
 permalink: /16-5-1/
 sdg_goal: '16'
 title: >-

--- a/meta/16-5-2.md
+++ b/meta/16-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.5.2
 layout: indicator
-indicator_sort_order: '0130'
+indicator_sort_order: 16-05-02
 permalink: /16-5-2/
 sdg_goal: '16'
 title: >-

--- a/meta/16-6-1.md
+++ b/meta/16-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.6.1
 layout: indicator
-indicator_sort_order: '0140'
+indicator_sort_order: 16-06-01
 permalink: /16-6-1/
 sdg_goal: '16'
 title: "Primary government expenditures as a proportion of original approved budget, by sector (or\_by budget codes or similar)"

--- a/meta/16-6-2.md
+++ b/meta/16-6-2.md
@@ -3,7 +3,7 @@ indicator: 16.6.2
 layout: indicator
 permalink: /16-6-2/
 sdg_goal: '16'
-indicator_sort_order: '0150'
+indicator_sort_order: 16-06-02
 title: >-
   Proportion of population satisfied with their last experience of public
   services

--- a/meta/16-7-1.md
+++ b/meta/16-7-1.md
@@ -3,7 +3,7 @@ indicator: 16.7.1
 layout: indicator
 permalink: /16-7-1/
 sdg_goal: '16'
-indicator_sort_order: '0160'
+indicator_sort_order: 16-07-01
 title: >-
   Proportions of positions (by sex, age, persons with disabilities and
   population groups) in public institutions (national and local legislatures,

--- a/meta/16-7-2.md
+++ b/meta/16-7-2.md
@@ -3,7 +3,7 @@ indicator: 16.7.2
 layout: indicator
 permalink: /16-7-2/
 sdg_goal: '16'
-indicator_sort_order: '0170'
+indicator_sort_order: 16-07-02
 title: >-
   Proportion of population who believe decision-making is inclusive and
   responsive, by sex, age, disability and population group

--- a/meta/16-8-1.md
+++ b/meta/16-8-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.8.1
 layout: indicator
-indicator_sort_order: '0180'
+indicator_sort_order: 16-08-01
 permalink: /16-8-1/
 sdg_goal: '16'
 title: >-

--- a/meta/16-9-1.md
+++ b/meta/16-9-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.9.1
 layout: indicator
-indicator_sort_order: '0190'
+indicator_sort_order: 16-09-01
 permalink: /16-9-1/
 sdg_goal: '16'
 title: >-

--- a/meta/16-a-1.md
+++ b/meta/16-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 16.a.1
 layout: indicator
-indicator_sort_order: '0220'
+indicator_sort_order: 16-aa-01
 permalink: /16-a-1/
 sdg_goal: '16'
 title: >-

--- a/meta/16-b-1.md
+++ b/meta/16-b-1.md
@@ -3,7 +3,7 @@ indicator: 16.b.1
 layout: indicator
 permalink: /16-b-1/
 sdg_goal: '16'
-indicator_sort_order: '0230'
+indicator_sort_order: 16-bb-01
 title: >-
   Proportion of population reporting having personally felt discriminated
   against or harassed in the previous 12 months on the basis of a ground of

--- a/meta/17-1-1.md
+++ b/meta/17-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: 17-01-01
 permalink: /17-1-1/
 sdg_goal: '17'
 title: Total government revenue as a proportion of GDP, by source

--- a/meta/17-1-2.md
+++ b/meta/17-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 17-01-02
 permalink: /17-1-2/
 sdg_goal: '17'
 title: Proportion of domestic budget funded by domestic taxes

--- a/meta/17-10-1.md
+++ b/meta/17-10-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.10.1
 layout: indicator
-indicator_sort_order: '0130'
+indicator_sort_order: 17-10-01
 permalink: /17-10-1/
 sdg_goal: '17'
 title: Worldwide weighted tariff-average

--- a/meta/17-11-1.md
+++ b/meta/17-11-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.11.1
 layout: indicator
-indicator_sort_order: '0140'
+indicator_sort_order: 17-11-01
 permalink: /17-11-1/
 sdg_goal: '17'
 title: Developing countries’ and least developed countries’ share of global exports

--- a/meta/17-12-1.md
+++ b/meta/17-12-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.12.1
 layout: indicator
-indicator_sort_order: '0150'
+indicator_sort_order: 17-12-01
 permalink: /17-12-1/
 sdg_goal: '17'
 title: >-

--- a/meta/17-13-1.md
+++ b/meta/17-13-1.md
@@ -3,7 +3,7 @@ indicator: 17.13.1
 layout: indicator
 permalink: /17-13-1/
 sdg_goal: '17'
-indicator_sort_order: '0160'
+indicator_sort_order: 17-13-01
 title: Macroeconomic Dashboard
 graph_type: line
 un_designated_tier: '3'

--- a/meta/17-14-1.md
+++ b/meta/17-14-1.md
@@ -3,7 +3,7 @@ indicator: 17.14.1
 layout: indicator
 permalink: /17-14-1/
 sdg_goal: '17'
-indicator_sort_order: '0170'
+indicator_sort_order: 17-14-01
 title: >-
   Number of countries with mechanisms in place to enhance policy coherence of
   sustainable development

--- a/meta/17-15-1.md
+++ b/meta/17-15-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.15.1
 layout: indicator
-indicator_sort_order: '0180'
+indicator_sort_order: 17-15-01
 permalink: /17-15-1/
 sdg_goal: '17'
 title: >-

--- a/meta/17-16-1.md
+++ b/meta/17-16-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.16.1
 layout: indicator
-indicator_sort_order: '0190'
+indicator_sort_order: 17-16-01
 permalink: /17-16-1/
 sdg_goal: '17'
 title: >-

--- a/meta/17-17-1.md
+++ b/meta/17-17-1.md
@@ -3,7 +3,7 @@ indicator: 17.17.1
 layout: indicator
 permalink: /17-17-1/
 sdg_goal: '17'
-indicator_sort_order: '0200'
+indicator_sort_order: 17-17-01
 title: >-
   Amount of United States dollars committed to public-private and civil society
   partnerships

--- a/meta/17-18-1.md
+++ b/meta/17-18-1.md
@@ -3,7 +3,7 @@ indicator: 17.18.1
 layout: indicator
 permalink: /17-18-1/
 sdg_goal: '17'
-indicator_sort_order: '0210'
+indicator_sort_order: 17-18-01
 title: >-
   Proportion of sustainable development indicators produced at the national
   level with full disaggregation when relevant to the target, in accordance with

--- a/meta/17-18-2.md
+++ b/meta/17-18-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.18.2
 layout: indicator
-indicator_sort_order: '0220'
+indicator_sort_order: 17-18-02
 permalink: /17-18-2/
 sdg_goal: '17'
 title: >-

--- a/meta/17-18-3.md
+++ b/meta/17-18-3.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.18.3
 layout: indicator
-indicator_sort_order: '0230'
+indicator_sort_order: 17-18-03
 permalink: /17-18-3/
 sdg_goal: '17'
 title: >-

--- a/meta/17-19-1.md
+++ b/meta/17-19-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.19.1
 layout: indicator
-indicator_sort_order: '0240'
+indicator_sort_order: 17-19-01
 permalink: /17-19-1/
 sdg_goal: '17'
 title: >-

--- a/meta/17-19-2.md
+++ b/meta/17-19-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.19.2
 layout: indicator
-indicator_sort_order: '0250'
+indicator_sort_order: 17-19-02
 permalink: /17-19-2/
 sdg_goal: '17'
 title: >-

--- a/meta/17-2-1.md
+++ b/meta/17-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 17-02-01
 permalink: /17-2-1/
 sdg_goal: '17'
 title: >-

--- a/meta/17-3-1.md
+++ b/meta/17-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.3.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 17-03-01
 permalink: /17-3-1/
 sdg_goal: '17'
 title: >-

--- a/meta/17-3-2.md
+++ b/meta/17-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.3.2
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 17-03-02
 permalink: /17-3-2/
 sdg_goal: '17'
 title: Volume of remittances (in United States dollars) as a proportion of total GDP

--- a/meta/17-4-1.md
+++ b/meta/17-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.4.1
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: 17-04-01
 permalink: /17-4-1/
 sdg_goal: '17'
 title: Debt service as a proportion of exports of goods and services

--- a/meta/17-5-1.md
+++ b/meta/17-5-1.md
@@ -3,7 +3,7 @@ indicator: 17.5.1
 layout: indicator
 permalink: /17-5-1/
 sdg_goal: '17'
-indicator_sort_order: '0070'
+indicator_sort_order: 17-05-01
 title: >-
   Number of countries that adopt and implement investment promotion regimes for
   least developed countries

--- a/meta/17-6-1.md
+++ b/meta/17-6-1.md
@@ -3,7 +3,7 @@ indicator: 17.6.1
 layout: indicator
 permalink: /17-6-1/
 sdg_goal: '17'
-indicator_sort_order: 0080
+indicator_sort_order: 17-06-01
 title: >-
   Number of science and/or technology cooperation agreements and programmes
   between countries, by type of cooperation

--- a/meta/17-6-2.md
+++ b/meta/17-6-2.md
@@ -3,7 +3,7 @@ indicator: 17.6.2
 layout: indicator
 permalink: /17-6-2/
 sdg_goal: '17'
-indicator_sort_order: 0090
+indicator_sort_order: 17-06-02
 title: 'Fixed Internet broadband subscriptions per 100 inhabitants, by speed'
 target_id: '17.6'
 target: >-

--- a/meta/17-7-1.md
+++ b/meta/17-7-1.md
@@ -3,7 +3,7 @@ indicator: 17.7.1
 layout: indicator
 permalink: /17-7-1/
 sdg_goal: '17'
-indicator_sort_order: '0100'
+indicator_sort_order: 17-07-01
 title: >-
   Total amount of approved funding for developing countries to promote the
   development, transfer, dissemination and diffusion of environmentally sound

--- a/meta/17-8-1.md
+++ b/meta/17-8-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.8.1
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: 17-08-01
 permalink: /17-8-1/
 sdg_goal: '17'
 title: Proportion of individuals using the Internet

--- a/meta/17-9-1.md
+++ b/meta/17-9-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 17.9.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: 17-09-01
 permalink: /17-9-1/
 sdg_goal: '17'
 title: >-

--- a/meta/2-1-1.md
+++ b/meta/2-1-1.md
@@ -3,7 +3,7 @@ indicator: 2.1.1
 layout: indicator
 permalink: /2-1-1/
 sdg_goal: '2'
-indicator_sort_order: '0010'
+indicator_sort_order: 02-01-01
 title: Prevalence of undernourishment
 graph_type: line
 un_designated_tier: '1'

--- a/meta/2-1-2.md
+++ b/meta/2-1-2.md
@@ -3,7 +3,7 @@ indicator: 2.1.2
 layout: indicator
 permalink: /2-1-2/
 sdg_goal: '2'
-indicator_sort_order: '0020'
+indicator_sort_order: 02-01-02
 title: >-
   Prevalence of moderate or severe food insecurity in the population, based on
   the Food Insecurity Experience Scale (FIES)

--- a/meta/2-2-1.md
+++ b/meta/2-2-1.md
@@ -3,7 +3,7 @@ indicator: 2.2.1
 layout: indicator
 permalink: /2-2-1/
 sdg_goal: '2'
-indicator_sort_order: '0030'
+indicator_sort_order: 02-02-01
 title: >-
   Prevalence of stunting (height for age <-2 standard deviation from the median
   of the World Health Organization (WHO) Child Growth Standards) among children

--- a/meta/2-2-2.md
+++ b/meta/2-2-2.md
@@ -3,7 +3,7 @@ indicator: 2.2.2
 layout: indicator
 permalink: /2-2-2/
 sdg_goal: '2'
-indicator_sort_order: '0040'
+indicator_sort_order: 02-02-02
 title: >-
   Prevalence of malnutrition (weight for height >+2 or <-2 standard deviation
   from the median of the WHO Child Growth Standards) among children under 5

--- a/meta/2-3-1.md
+++ b/meta/2-3-1.md
@@ -3,7 +3,7 @@ indicator: 2.3.1
 layout: indicator
 permalink: /2-3-1/
 sdg_goal: '2'
-indicator_sort_order: '0050'
+indicator_sort_order: 02-03-01
 title: >-
   Volume of production per labour unit by classes of farming/pastoral/forestry
   enterprise size

--- a/meta/2-3-2.md
+++ b/meta/2-3-2.md
@@ -3,7 +3,7 @@ indicator: 2.3.2
 layout: indicator
 permalink: /2-3-2/
 sdg_goal: '2'
-indicator_sort_order: '0060'
+indicator_sort_order: 02-03-02
 title: 'Average income of small-scale food producers, by sex and indigenous status'
 target_id: '2.3'
 target: >-

--- a/meta/2-4-1.md
+++ b/meta/2-4-1.md
@@ -3,7 +3,7 @@ indicator: 2.4.1
 layout: indicator
 permalink: /2-4-1/
 sdg_goal: '2'
-indicator_sort_order: '0070'
+indicator_sort_order: 02-04-01
 title: Proportion of agricultural area under productive and sustainable agriculture
 target_id: '2.4'
 target: >-

--- a/meta/2-5-1.md
+++ b/meta/2-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.5.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 02-05-01
 permalink: /2-5-1/
 sdg_goal: '2'
 title: >-

--- a/meta/2-5-2.md
+++ b/meta/2-5-2.md
@@ -3,7 +3,7 @@ indicator: 2.5.2
 layout: indicator
 permalink: /2-5-2/
 sdg_goal: '2'
-indicator_sort_order: 0090
+indicator_sort_order: 02-05-02
 title: >-
   Proportion of local breeds classified as being at risk, not-at-risk or at
   unknown level of risk of extinction

--- a/meta/2-a-1.md
+++ b/meta/2-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.a.1
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: 02-aa-01
 permalink: /2-a-1/
 sdg_goal: '2'
 title: The agriculture orientation index for government expenditures

--- a/meta/2-a-2.md
+++ b/meta/2-a-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.a.2
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: 02-aa-02
 permalink: /2-a-2/
 sdg_goal: '2'
 title: >-

--- a/meta/2-b-1.md
+++ b/meta/2-b-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.b.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: 02-bb-01
 permalink: /2-b-1/
 sdg_goal: '2'
 title: Agricultural export subsidies

--- a/meta/2-c-1.md
+++ b/meta/2-c-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 2.c.1
 layout: indicator
-indicator_sort_order: '0130'
+indicator_sort_order: 02-cc-01
 permalink: /2-c-1/
 sdg_goal: '2'
 title: Indicator of food price anomalies

--- a/meta/3-1-1.md
+++ b/meta/3-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: 03-01-01
 permalink: /3-1-1/
 sdg_goal: '3'
 title: Maternal mortality ratio

--- a/meta/3-1-2.md
+++ b/meta/3-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 03-01-02
 permalink: /3-1-2/
 sdg_goal: '3'
 title: Proportion of births attended by skilled health personnel

--- a/meta/3-2-1.md
+++ b/meta/3-2-1.md
@@ -3,7 +3,7 @@ indicator: 3.2.1
 layout: indicator
 permalink: /3-2-1/
 sdg_goal: '3'
-indicator_sort_order: '0030'
+indicator_sort_order: 03-02-01
 title: Under-five mortality rate
 target_id: '3.2'
 target: >-

--- a/meta/3-2-2.md
+++ b/meta/3-2-2.md
@@ -3,7 +3,7 @@ indicator: 3.2.2
 layout: indicator
 permalink: /3-2-2/
 sdg_goal: '3'
-indicator_sort_order: '0040'
+indicator_sort_order: 03-02-02
 title: Neonatal mortality rate
 target_id: '3.2'
 target: >-

--- a/meta/3-3-1.md
+++ b/meta/3-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.3.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 03-03-01
 permalink: /3-3-1/
 sdg_goal: '3'
 title: >-

--- a/meta/3-3-2.md
+++ b/meta/3-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.3.2
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: 03-03-02
 permalink: /3-3-2/
 sdg_goal: '3'
 target: >-

--- a/meta/3-3-3.md
+++ b/meta/3-3-3.md
@@ -42,7 +42,7 @@ source_release_date_2: 28/06/2018
 source_next_release_2: 01/06/2019
 source_statistical_classification_2: National Statistic
 source_contact_2: pop.info@ons.gsi.gov.uk
-indicator_sort_order: 0070
+indicator_sort_order: 03-03-03
 title: >-
   Malaria incidence per 1,000 population
 comments_limitations:  Data follows the UN specification for this indicator. This indicator has not been identified in collaboration with topic experts.

--- a/meta/3-3-4.md
+++ b/meta/3-3-4.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.3.4
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 03-03-04
 permalink: /3-3-4/
 sdg_goal: '3'
 title: 'Hepatitis B incidence per 100,000 population'

--- a/meta/3-3-5.md
+++ b/meta/3-3-5.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.3.5
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: 03-03-05
 permalink: /3-3-5/
 sdg_goal: '3'
 title: Number of people requiring interventions against neglected tropical diseases

--- a/meta/3-4-1.md
+++ b/meta/3-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.4.1
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: 03-04-01
 permalink: /3-4-1/
 sdg_goal: '3'
 title: >-

--- a/meta/3-4-2.md
+++ b/meta/3-4-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.4.2
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: 03-04-02
 permalink: /3-4-2/
 sdg_goal: '3'
 title: Suicide mortality rate

--- a/meta/3-5-1.md
+++ b/meta/3-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.5.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: 03-05-01
 permalink: /3-5-1/
 sdg_goal: '3'
 title: >-

--- a/meta/3-5-2.md
+++ b/meta/3-5-2.md
@@ -3,7 +3,7 @@ indicator: 3.5.2
 layout: indicator
 permalink: /3-5-2/
 sdg_goal: '3'
-indicator_sort_order: '0130'
+indicator_sort_order: 03-05-02
 title: >-
   Harmful use of alcohol, defined according to the national context as alcohol
   per capita consumption (aged 15 years and older) within a calendar year in

--- a/meta/3-6-1.md
+++ b/meta/3-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.6.1
 layout: indicator
-indicator_sort_order: '0140'
+indicator_sort_order: 03-06-01
 permalink: /3-6-1/
 sdg_goal: '3'
 title: Death rate due to road traffic injuries

--- a/meta/3-7-1.md
+++ b/meta/3-7-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.7.1
 layout: indicator
-indicator_sort_order: '0150'
+indicator_sort_order: 03-07-01
 permalink: /3-7-1/
 sdg_goal: '3'
 target: >-

--- a/meta/3-7-2.md
+++ b/meta/3-7-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.7.2
 layout: indicator
-indicator_sort_order: '0160'
+indicator_sort_order: 03-07-02
 permalink: /3-7-2/
 sdg_goal: '3'
 title: >-

--- a/meta/3-8-1.md
+++ b/meta/3-8-1.md
@@ -3,7 +3,7 @@ indicator: 3.8.1
 layout: indicator
 permalink: /3-8-1/
 sdg_goal: '3'
-indicator_sort_order: '0170'
+indicator_sort_order: 03-08-01
 title: >-
   Coverage of essential health services (defined as the average coverage of
   essential services based on tracer interventions that include reproductive,

--- a/meta/3-8-2.md
+++ b/meta/3-8-2.md
@@ -3,7 +3,7 @@ indicator: 3.8.2
 layout: indicator
 permalink: /3-8-2/
 sdg_goal: '3'
-indicator_sort_order: 0180
+indicator_sort_order: 03-08-02
 title: >-
   Proportion of population with large household expenditures on health as a
   share of total household expenditure or income

--- a/meta/3-9-1.md
+++ b/meta/3-9-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.9.1
 layout: indicator
-indicator_sort_order: '0190'
+indicator_sort_order: 03-09-01
 permalink: /3-9-1/
 sdg_goal: '3'
 title: Mortality rate attributed to household and ambient air pollution

--- a/meta/3-9-2.md
+++ b/meta/3-9-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.9.2
 layout: indicator
-indicator_sort_order: '0200'
+indicator_sort_order: 03-09-02
 permalink: /3-9-2/
 sdg_goal: '3'
 title: >-

--- a/meta/3-9-3.md
+++ b/meta/3-9-3.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.9.3
 layout: indicator
-indicator_sort_order: '0210'
+indicator_sort_order: 03-09-03
 permalink: /3-9-3/
 sdg_goal: '3'
 title: Mortality rate attributed to unintentional poisoning

--- a/meta/3-a-1.md
+++ b/meta/3-a-1.md
@@ -3,7 +3,7 @@ layout: indicator
 sdg_goal: '3'
 target_id: '3.a'
 permalink: /3-a-1/
-indicator_sort_order: 0220
+indicator_sort_order: 03-aa-01
 published: true
 target: 3.a Strengthen the implementation of the World Health Organization Framework Convention on Tobacco Control in all countries, as appropriate
 indicator: 3.a.1

--- a/meta/3-b-1.md
+++ b/meta/3-b-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.b.1
 layout: indicator
-indicator_sort_order: '0230'
+indicator_sort_order: 03-bb-01
 permalink: /3-b-1/
 sdg_goal: '3'
 title: >-

--- a/meta/3-b-2.md
+++ b/meta/3-b-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.b.2
 layout: indicator
-indicator_sort_order: '0240'
+indicator_sort_order: 03-bb-02
 permalink: /3-b-2/
 sdg_goal: '3'
 title: >-

--- a/meta/3-b-3.md
+++ b/meta/3-b-3.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.b.3
 layout: indicator
-indicator_sort_order: '0250'
+indicator_sort_order: 03-bb-03
 permalink: /3-b-3/
 sdg_goal: '3'
 graph_type: line

--- a/meta/3-c-1.md
+++ b/meta/3-c-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.c.1
 layout: indicator
-indicator_sort_order: '0260'
+indicator_sort_order: 03-cc-01
 permalink: /3-c-1/
 sdg_goal: '3'
 title: Health worker density and distribution

--- a/meta/3-d-1.md
+++ b/meta/3-d-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 3.d.1
 layout: indicator
-indicator_sort_order: '0270'
+indicator_sort_order: 03-dd-01
 permalink: /3-d-1/
 sdg_goal: '3'
 title: >-

--- a/meta/4-1-1.md
+++ b/meta/4-1-1.md
@@ -3,7 +3,7 @@ indicator: 4.1.1
 layout: indicator
 permalink: /4-1-1/
 sdg_goal: '4'
-indicator_sort_order: '0010'
+indicator_sort_order: 04-01-01
 title: >-
   Proportion of children and young people: (a) in grades 2/3; (b) at the end of
   primary; and (c) at the end of lower secondary achieving at least a minimum

--- a/meta/4-2-1.md
+++ b/meta/4-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 04-02-01
 permalink: /4-2-1/
 sdg_goal: '4'
 title: >-

--- a/meta/4-2-2.md
+++ b/meta/4-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.2.2
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 04-02-02
 permalink: /4-2-2/
 sdg_goal: '4'
 title: >-

--- a/meta/4-3-1.md
+++ b/meta/4-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.3.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 04-03-01
 permalink: /4-3-1/
 sdg_goal: '4'
 title: >-

--- a/meta/4-4-1.md
+++ b/meta/4-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.4.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 04-04-01
 permalink: /4-4-1/
 sdg_goal: '4'
 title: >-

--- a/meta/4-5-1.md
+++ b/meta/4-5-1.md
@@ -3,7 +3,7 @@ indicator: 4.5.1
 layout: indicator
 permalink: /4-5-1/
 sdg_goal: '4'
-indicator_sort_order: '0060'
+indicator_sort_order: 04-05-01
 title: >-
   Parity indices (female/male, rural/urban, bottom/top wealth quintile and
   others such as disability status, indigenous peoples and conflict-affected, as

--- a/meta/4-6-1.md
+++ b/meta/4-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.6.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: 04-06-01
 permalink: /4-6-1/
 sdg_goal: '4'
 title: >-

--- a/meta/4-7-1.md
+++ b/meta/4-7-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.7.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 04-07-01
 permalink: /4-7-1/
 sdg_goal: '4'
 title: "Extent to which (i) global citizenship education and (ii) education for sustainable development, including gender equality and human rights, are mainstreamed at all levels in: (a) national education policies; (b) curricula; (c) teacher education; and (d)\_student assessment"

--- a/meta/4-a-1.md
+++ b/meta/4-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.a.1
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: 04-aa-01
 permalink: /4-a-1/
 sdg_goal: '4'
 title: "Proportion of schools with access to: (a)\_electricity; (b) the Internet for pedagogical purposes; (c) computers for pedagogical purposes; (d)\_adapted infrastructure and materials for students with disabilities; (e) basic drinking water; (f) single-sex basic sanitation facilities; and (g) basic handwashing facilities (as per the WASH indicator definitions)"

--- a/meta/4-b-1.md
+++ b/meta/4-b-1.md
@@ -3,7 +3,7 @@ indicator: 4.b.1
 layout: indicator
 permalink: /4-b-1/
 sdg_goal: '4'
-indicator_sort_order: '0100'
+indicator_sort_order: 04-bb-01
 title: >-
   Volume of official development assistance flows for scholarships by sector and
   type of study

--- a/meta/4-c-1.md
+++ b/meta/4-c-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 4.c.1
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: 04-cc-01
 permalink: /4-c-1/
 sdg_goal: '4'
 title: >-

--- a/meta/5-1-1.md
+++ b/meta/5-1-1.md
@@ -3,7 +3,7 @@ indicator: 5.1.1
 layout: indicator
 permalink: /5-1-1/
 sdg_goal: '5'
-indicator_sort_order: '0010'
+indicator_sort_order: 05-01-01
 title: >-
   Whether or not legal frameworks are in place to promote, enforce and monitor
   equality and non‑discrimination on the basis of sex

--- a/meta/5-2-1.md
+++ b/meta/5-2-1.md
@@ -3,7 +3,7 @@ indicator: 5.2.1
 layout: indicator
 permalink: /5-2-1/
 sdg_goal: '5'
-indicator_sort_order: '0020'
+indicator_sort_order: 05-02-01
 title: >-
   Proportion of ever-partnered women and girls aged 15 years and older subjected
   to physical, sexual or psychological violence by a current or former intimate

--- a/meta/5-2-2.md
+++ b/meta/5-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.2.2
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 05-02-02
 permalink: /5-2-2/
 sdg_goal: '5'
 title: >-

--- a/meta/5-3-1.md
+++ b/meta/5-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.3.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 05-03-01
 permalink: /5-3-1/
 sdg_goal: '5'
 title: >-

--- a/meta/5-3-2.md
+++ b/meta/5-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.3.2
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 05-03-02
 permalink: /5-3-2/
 sdg_goal: '5'
 title: >-

--- a/meta/5-4-1.md
+++ b/meta/5-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.4.1
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: 05-04-01
 permalink: /5-4-1/
 sdg_goal: '5'
 title: >-

--- a/meta/5-5-1.md
+++ b/meta/5-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.5.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: 05-05-01
 permalink: /5-5-1/
 sdg_goal: '5'
 title: >-

--- a/meta/5-5-2.md
+++ b/meta/5-5-2.md
@@ -3,7 +3,7 @@ indicator: 5.5.2
 layout: indicator
 permalink: /5-5-2/
 sdg_goal: '5'
-indicator_sort_order: 0080
+indicator_sort_order: 05-05-02
 title: Proportion of women in managerial positions
 target_id: '5.5'
 target: >-

--- a/meta/5-6-1.md
+++ b/meta/5-6-1.md
@@ -3,7 +3,7 @@ indicator: 5.6.1
 layout: indicator
 permalink: /5-6-1/
 sdg_goal: '5'
-indicator_sort_order: 0090
+indicator_sort_order: 05-06-01
 title: >-
   Proportion of women aged 15-49 years who make their own informed decisions
   regarding sexual relations, contraceptive use and reproductive health care

--- a/meta/5-6-2.md
+++ b/meta/5-6-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.6.2
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: 05-06-02
 permalink: /5-6-2/
 sdg_goal: '5'
 title: >-

--- a/meta/5-a-1.md
+++ b/meta/5-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.a.1
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: 05-aa-01
 permalink: /5-a-1/
 sdg_goal: '5'
 title: >-

--- a/meta/5-a-2.md
+++ b/meta/5-a-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.a.2
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: 05-aa-02
 permalink: /5-a-2/
 sdg_goal: '5'
 title: >-

--- a/meta/5-b-1.md
+++ b/meta/5-b-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.b.1
 layout: indicator
-indicator_sort_order: '0130'
+indicator_sort_order: 05-bb-01
 permalink: /5-b-1/
 sdg_goal: '5'
 title: Proportion of individuals who own a mobile telephone, by sex

--- a/meta/5-c-1.md
+++ b/meta/5-c-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 5.c.1
 layout: indicator
-indicator_sort_order: '0140'
+indicator_sort_order: 05-cc-01
 permalink: /5-c-1/
 sdg_goal: '5'
 title: >-

--- a/meta/6-1-1.md
+++ b/meta/6-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: 06-01-01
 permalink: /6-1-1/
 sdg_goal: '6'
 target: >-

--- a/meta/6-2-1.md
+++ b/meta/6-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 06-02-01
 permalink: /6-2-1/
 sdg_goal: '6'
 title: >-

--- a/meta/6-3-1.md
+++ b/meta/6-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.3.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 06-03-01
 permalink: /6-3-1/
 sdg_goal: '6'
 title: Proportion of wastewater safely treated

--- a/meta/6-3-2.md
+++ b/meta/6-3-2.md
@@ -3,7 +3,7 @@ indicator: 6.3.2
 layout: indicator
 permalink: /6-3-2/
 sdg_goal: '6'
-indicator_sort_order: '0040'
+indicator_sort_order: 06-03-02
 title: Proportion of bodies of water with good ambient water quality
 target_id: '6.3'
 target: >-

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.4.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 06-04-01
 permalink: /6-4-1/
 sdg_goal: '6'
 title: Change in water-use efficiency over time

--- a/meta/6-4-2.md
+++ b/meta/6-4-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.4.2
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: 06-04-02
 permalink: /6-4-2/
 sdg_goal: '6'
 title: >-

--- a/meta/6-5-1.md
+++ b/meta/6-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.5.1
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: 06-05-01
 permalink: /6-5-1/
 sdg_goal: '6'
 title: Degree of integrated water resources management implementation (0-100)

--- a/meta/6-5-2.md
+++ b/meta/6-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.5.2
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 06-05-02
 permalink: /6-5-2/
 sdg_goal: '6'
 title: >-

--- a/meta/6-6-1.md
+++ b/meta/6-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.6.1
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: 06-06-01
 permalink: /6-6-1/
 sdg_goal: '6'
 title: Change in the extent of water-related ecosystems over time

--- a/meta/6-a-1.md
+++ b/meta/6-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.a.1
 layout: indicator
-indicator_sort_order: '0100'
+indicator_sort_order: 06-aa-01
 permalink: /6-a-1/
 sdg_goal: '6'
 title: >-

--- a/meta/6-b-1.md
+++ b/meta/6-b-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 6.b.1
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: 06-bb-01
 permalink: /6-b-1/
 sdg_goal: '6'
 title: >-

--- a/meta/7-1-1.md
+++ b/meta/7-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 7.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: 07-01-01
 permalink: /7-1-1/
 sdg_goal: '7'
 title: Proportion of population with access to electricity

--- a/meta/7-1-2.md
+++ b/meta/7-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 7.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 07-01-02
 permalink: /7-1-2/
 sdg_goal: '7'
 title: >-

--- a/meta/7-2-1.md
+++ b/meta/7-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 7.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 07-02-01
 permalink: /7-2-1/
 sdg_goal: '7'
 title: Renewable energy share in the total final energy consumption

--- a/meta/7-3-1.md
+++ b/meta/7-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 7.3.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 07-03-01
 permalink: /7-3-1/
 sdg_goal: '7'
 title: Energy intensity measured in terms of primary energy and GDP

--- a/meta/7-a-1.md
+++ b/meta/7-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 7.a.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 07-aa-01
 permalink: /7-a-1/
 sdg_goal: '7'
 title: >-

--- a/meta/7-b-1.md
+++ b/meta/7-b-1.md
@@ -3,7 +3,7 @@ indicator: 7.b.1
 layout: indicator
 permalink: /7-b-1/
 sdg_goal: '7'
-indicator_sort_order: '0060'
+indicator_sort_order: 07-bb-01
 title: >-
   Investments in energy efficiency as a proportion of GDP and the amount of
   foreign direct investment in financial transfer for infrastructure and

--- a/meta/8-1-1.md
+++ b/meta/8-1-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.1.1
 layout: indicator
-indicator_sort_order: '0010'
+indicator_sort_order: 08-01-01
 permalink: /8-1-1/
 sdg_goal: '8'
 title: Annual growth rate of real GDP per capita

--- a/meta/8-10-1.md
+++ b/meta/8-10-1.md
@@ -3,7 +3,7 @@ indicator: 8.10.1
 layout: indicator
 permalink: /8-10-1/
 sdg_goal: '8'
-indicator_sort_order: '0140'
+indicator_sort_order: 08-10-01
 title: >-
   (a) Number of commercial bank branches per 100,000 adults and (b) number of
   automated teller machines (ATMs) per 100,000 adults

--- a/meta/8-10-2.md
+++ b/meta/8-10-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.10.2
 layout: indicator
-indicator_sort_order: '0150'
+indicator_sort_order: 08-10-02
 permalink: /8-10-2/
 sdg_goal: '8'
 title: >-

--- a/meta/8-2-1.md
+++ b/meta/8-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.2.1
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 08-02-01
 permalink: /8-2-1/
 sdg_goal: '8'
 title: Annual growth rate of real GDP per employed person

--- a/meta/8-3-1.md
+++ b/meta/8-3-1.md
@@ -3,7 +3,7 @@ indicator: 8.3.1
 layout: indicator
 permalink: /8-3-1/
 sdg_goal: '8'
-indicator_sort_order: '0030'
+indicator_sort_order: 08-03-01
 title: 'Proportion of informal employment in non-agriculture employment, by sex'
 target_id: '8.3'
 target: >-

--- a/meta/8-4-1.md
+++ b/meta/8-4-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.4.1
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 08-04-01
 permalink: /8-4-1/
 sdg_goal: '8'
 title: >-

--- a/meta/8-4-2.md
+++ b/meta/8-4-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.4.2
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 08-04-02
 permalink: /8-4-2/
 sdg_goal: '8'
 title: >-

--- a/meta/8-5-1.md
+++ b/meta/8-5-1.md
@@ -3,7 +3,7 @@ layout: indicator
 sdg_goal: '8'
 target_id: '8.5'
 permalink: /8-5-1/
-indicator_sort_order: 0060
+indicator_sort_order: 08-05-01
 published: true
 target: 8.5 By 2030, achieve full and productive employment and decent work for all women and men, including for young people and persons with disabilities, and equal pay for work of equal value
 indicator: 8.5.1

--- a/meta/8-5-2.md
+++ b/meta/8-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.5.2
 layout: indicator
-indicator_sort_order: '0070'
+indicator_sort_order: 08-05-02
 permalink: /8-5-2/
 sdg_goal: '8'
 title: Unemployment rate, by sex, age and persons with disabilities

--- a/meta/8-6-1.md
+++ b/meta/8-6-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.6.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 08-06-01
 permalink: /8-6-1/
 sdg_goal: '8'
 title: >-

--- a/meta/8-7-1.md
+++ b/meta/8-7-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.7.1
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: 08-07-01
 permalink: /8-7-1/
 sdg_goal: '8'
 title: "Proportion and number of children aged 5‑17\_years engaged in child labour, by sex and age"

--- a/meta/8-8-1.md
+++ b/meta/8-8-1.md
@@ -3,7 +3,7 @@ indicator: 8.8.1
 layout: indicator
 permalink: /8-8-1/
 sdg_goal: '8'
-indicator_sort_order: '0100'
+indicator_sort_order: 08-08-01
 title: >-
   Frequency rates of fatal and non-fatal occupational injuries, by sex and
   migrant status

--- a/meta/8-8-2.md
+++ b/meta/8-8-2.md
@@ -3,7 +3,7 @@ indicator: 8.8.2
 layout: indicator
 permalink: /8-8-2/
 sdg_goal: '8'
-indicator_sort_order: '0110'
+indicator_sort_order: 08-08-02
 title: >-
   Level of national compliance of labour rights (freedom of association and
   collective bargaining) based on International Labour Organization (ILO)

--- a/meta/8-9-1.md
+++ b/meta/8-9-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.9.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: 08-09-01
 permalink: /8-9-1/
 sdg_goal: '8'
 title: Tourism direct GDP as a proportion of total GDP and in growth rate

--- a/meta/8-9-2.md
+++ b/meta/8-9-2.md
@@ -3,7 +3,7 @@ indicator: 8.9.2
 layout: indicator
 permalink: /8-9-2/
 sdg_goal: '8'
-indicator_sort_order: '0130'
+indicator_sort_order: 08-09-02
 title: Proportion of jobs in sustainable tourism industries out of total tourism jobs
 target_id: '8.9'
 target: >-

--- a/meta/8-a-1.md
+++ b/meta/8-a-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.a.1
 layout: indicator
-indicator_sort_order: '0160'
+indicator_sort_order: 08-aa-01
 permalink: /8-a-1/
 sdg_goal: '8'
 title: Aid for Trade commitments and disbursements

--- a/meta/8-b-1.md
+++ b/meta/8-b-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 8.b.1
 layout: indicator
-indicator_sort_order: '0170'
+indicator_sort_order: 08-bb-01
 permalink: /8-b-1/
 sdg_goal: '8'
 title: >-

--- a/meta/9-1-1.md
+++ b/meta/9-1-1.md
@@ -3,7 +3,7 @@ indicator: 9.1.1
 layout: indicator
 permalink: /9-1-1/
 sdg_goal: '9'
-indicator_sort_order: '0010'
+indicator_sort_order: 09-01-01
 title: "Proportion of the rural population who live within 2\_km of an all-season road"
 graph_type: line
 un_designated_tier: '3'

--- a/meta/9-1-2.md
+++ b/meta/9-1-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.1.2
 layout: indicator
-indicator_sort_order: '0020'
+indicator_sort_order: 09-01-02
 permalink: /9-1-2/
 sdg_goal: '9'
 title: Passenger and freight volumes, by mode of transport

--- a/meta/9-2-1.md
+++ b/meta/9-2-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.2.1
 layout: indicator
-indicator_sort_order: '0030'
+indicator_sort_order: 09-02-01
 permalink: /9-2-1/
 sdg_goal: '9'
 title: Manufacturing value added as a proportion of GDP and per capita

--- a/meta/9-2-2.md
+++ b/meta/9-2-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.2.2
 layout: indicator
-indicator_sort_order: '0040'
+indicator_sort_order: 09-02-02
 permalink: /9-2-2/
 sdg_goal: '9'
 title: Manufacturing employment as a proportion of total employment

--- a/meta/9-3-1.md
+++ b/meta/9-3-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.3.1
 layout: indicator
-indicator_sort_order: '0050'
+indicator_sort_order: 09-03-01
 permalink: /9-3-1/
 sdg_goal: '9'
 title: Proportion of small-scale industries in total industry value added

--- a/meta/9-3-2.md
+++ b/meta/9-3-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.3.2
 layout: indicator
-indicator_sort_order: '0060'
+indicator_sort_order: 09-03-02
 permalink: /9-3-2/
 sdg_goal: '9'
 title: Proportion of small-scale industries with a loan or line of credit

--- a/meta/9-4-1.md
+++ b/meta/9-4-1.md
@@ -3,7 +3,7 @@ indicator: 9.4.1
 layout: indicator
 permalink: /9-4-1/
 sdg_goal: '9'
-indicator_sort_order: '0070'
+indicator_sort_order: 09-04-01
 title: CO2 emission per unit of value added
 target_id: '9.4'
 target: >-

--- a/meta/9-5-1.md
+++ b/meta/9-5-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.5.1
 layout: indicator
-indicator_sort_order: '0080'
+indicator_sort_order: 09-05-01
 permalink: /9-5-1/
 sdg_goal: '9'
 title: Research and development expenditure as a proportion of GDP

--- a/meta/9-5-2.md
+++ b/meta/9-5-2.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.5.2
 layout: indicator
-indicator_sort_order: '0090'
+indicator_sort_order: 09-05-02
 permalink: /9-5-2/
 sdg_goal: '9'
 title: Researchers (in full-time equivalent) per million inhabitants

--- a/meta/9-a-1.md
+++ b/meta/9-a-1.md
@@ -3,7 +3,7 @@ indicator: 9.a.1
 layout: indicator
 permalink: /9-a-1/
 sdg_goal: '9'
-indicator_sort_order: '0100'
+indicator_sort_order: 09-aa-01
 title: >-
   Total official international support (official development assistance plus
   other official flows) to infrastructure

--- a/meta/9-b-1.md
+++ b/meta/9-b-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.b.1
 layout: indicator
-indicator_sort_order: '0110'
+indicator_sort_order: 09-bb-01
 permalink: /9-b-1/
 sdg_goal: '9'
 title: >-

--- a/meta/9-c-1.md
+++ b/meta/9-c-1.md
@@ -1,7 +1,7 @@
 ---
 indicator: 9.c.1
 layout: indicator
-indicator_sort_order: '0120'
+indicator_sort_order: 09-cc-01
 permalink: /9-c-1/
 sdg_goal: '9'
 title: 'Proportion of population covered by a mobile network, by technology'


### PR DESCRIPTION
This changes the indicator_sort_order of every indicator, so that it is a non-numeric value that more accurately represents the indicator id.

As an example, 3.2.2 becomes 03-02-02

Letters get doubled, for example, 3.a.1 becomes 03-aa-01
