### PR TITLE
Reporting status edit - DON'T MERGE

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -140,8 +140,6 @@ prose:
             options:
               - name: 'notstarted'
                 value: 'notstarted'
-              - name: 'inprogress'
-                value: 'inprogress'
               - name: 'complete'
                 value: 'complete'
             scope: data

--- a/meta/1-a-3.md
+++ b/meta/1-a-3.md
@@ -5,7 +5,7 @@ permalink: /1-a-3/
 sdg_goal: '1'
 indicator_sort_order: 01-aa-03
 graph_type: line
-reporting_status: inprogress
+reporting_status: notstarted
 title: >-
   Sum of total grants and non-debt-creating inflows directly allocated to
   poverty reduction programmes as a proportion of GDP

--- a/meta/10-7-2.md
+++ b/meta/10-7-2.md
@@ -15,7 +15,7 @@ target: >-
   Facilitate orderly, safe, regular and responsible migration and mobility of
   people, including through the implementation of planned and well-managed
   migration policies
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C100702
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)

--- a/meta/12-b-1.md
+++ b/meta/12-b-1.md
@@ -18,7 +18,7 @@ indicator_name: >-
 target: >-
   Develop and implement tools to monitor sustainable development impacts for
   sustainable tourism that creates jobs and promotes local culture and products
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C120b01
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/14-6-1.md
+++ b/meta/14-6-1.md
@@ -20,7 +20,7 @@ target: >-
   subsidies, recognizing that appropriate and effective special and differential
   treatment for developing and least developed countries should be an integral
   part of the World Trade Organization fisheries subsidies negotiationb
-reporting_status: inprogress
+reporting_status: notstarted
 un_designated_tier: '3'
 un_custodian_agency: FAO
 un_sd_indicator_code: C140601

--- a/meta/14-b-1.md
+++ b/meta/14-b-1.md
@@ -20,7 +20,7 @@ indicator_name: >-
 target: >-
   Provide access for small-scale artisanal fishers to marine resources and
   markets
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C140b01
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)

--- a/meta/14-c-1.md
+++ b/meta/14-c-1.md
@@ -27,7 +27,7 @@ target: >-
   on the Law of the Sea, which provides the legal framework for the conservation
   and sustainable use of oceans and their resources, as recalled in paragraph
   158 of “The future we want”
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C140c01
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)

--- a/meta/15-9-1.md
+++ b/meta/15-9-1.md
@@ -18,7 +18,7 @@ indicator_name: >-
 target: >-
   By 2020, integrate ecosystem and biodiversity values into national and local
   planning, development processes, poverty reduction strategies and accounts
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C150901
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)

--- a/meta/16-2-2.md
+++ b/meta/16-2-2.md
@@ -17,7 +17,7 @@ indicator_name: >-
 target: >-
   End abuse, exploitation, trafficking and all forms of violence against and
   torture of children
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C160202
 un_notes: 'IAEG-SDG 3rd meeting: Lack of sufficient data coverage'
 published: true

--- a/meta/17-18-2.md
+++ b/meta/17-18-2.md
@@ -21,7 +21,7 @@ target: >-
   disaggregated by income, gender, age, race, ethnicity, migratory status,
   disability, geographic location and other characteristics relevant in national
   contexts
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C171802
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-18-3.md
+++ b/meta/17-18-3.md
@@ -21,7 +21,7 @@ target: >-
   disaggregated by income, gender, age, race, ethnicity, migratory status,
   disability, geographic location and other characteristics relevant in national
   contexts
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C171803
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/2-2-1.md
+++ b/meta/2-2-1.md
@@ -21,7 +21,7 @@ target: >-
   internationally agreed targets on stunting and wasting in children under 5
   years of age, and address the nutritional needs of adolescent girls, pregnant
   and lactating women and older persons
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C020201
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
 published: true

--- a/meta/2-c-1.md
+++ b/meta/2-c-1.md
@@ -15,7 +15,7 @@ target: >-
   their derivatives and facilitate timely access to market information,
   including on food reserves, in order to help limit extreme food price
   volatility
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C020c01
 un_notes: Fast Track; Reviewed at 5th IAEG-SDG meeting
 published: true

--- a/meta/3-1-1.md
+++ b/meta/3-1-1.md
@@ -13,7 +13,7 @@ indicator_name: Maternal mortality ratio
 target: >-
   By 2030, reduce the global maternal mortality ratio to less than 70 per
   100,000 live births
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C030101
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)

--- a/meta/3-7-1.md
+++ b/meta/3-7-1.md
@@ -18,7 +18,7 @@ un_designated_tier: '1'
 un_custodian_agency: DESA Population Division
 graph: bar
 target_id: '3.7'
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C030701
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)

--- a/meta/3-d-1.md
+++ b/meta/3-d-1.md
@@ -18,7 +18,7 @@ target: >-
   Strengthen the capacity of all countries, in particular developing countries,
   for early warning, risk reduction and management of national and global health
   risks
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C030d01
 published: true
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)

--- a/meta/4-a-1.md
+++ b/meta/4-a-1.md
@@ -48,7 +48,7 @@ source_other_info_1: >-
   document through the following link
   https://www.gov.uk/government/statistics/statistics-on-international-development-2016
   .
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C040a01
 un_notes: 'IAEG-SDG 3rd meeting: Lack of sufficient data coverage'
 published: true

--- a/meta/5-6-1.md
+++ b/meta/5-6-1.md
@@ -19,7 +19,7 @@ target: >-
   rights as agreed in accordance with the Programme of Action of the
   International Conference on Population and Development and the Beijing
   Platform for Action and the outcome documents of their review conferences
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C050601
 un_notes: 'IAEG-SDG 3rd meeting: There is an established methodology for the indicator'
 published: true

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -16,7 +16,7 @@ target: >-
   ensure sustainable withdrawals and supply of freshwater to address water
   scarcity and substantially reduce the number of people suffering from water
   scarcity
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C060401
 un_notes: >-
   Fast Track; Reviewed at 5th IAEG-SDG meeting; More information on terminology

--- a/meta/6-4-2.md
+++ b/meta/6-4-2.md
@@ -19,7 +19,7 @@ target: >-
   ensure sustainable withdrawals and supply of freshwater to address water
   scarcity and substantially reduce the number of people suffering from water
   scarcity
-reporting_status: inprogress
+reporting_status: notstarted
 un_sd_indicator_code: C060402
 un_notes: 'IAEG-SDG 3rd meeting: Lack of sufficient data coverage'
 published: true


### PR DESCRIPTION
Test edit to remove 'inprogress' from Reporting Status, leaving two colours. I'll also need to edit `_layouts/reportingstatus.html,`,  `_layouts/goal.html`, `_layouts/search.html` and `assets/js/reportingStatus.js` to remove the 'In Progress' label: https://github.com/ONSdigital/sdg-indicators/pull/2876

Indicators marked 'inprogress' on 10 December 2018...
3-1-1.md
16-2-2.md
17-18-2.md
17-18-3.md
2-c-1.md
3-7-1.md
3-d-1.md
6-4-1.md
6-4-2.md
1-a-3.md
10-7-2.md
12-b-1.md
14-6-1.md
14-b-1.md
15-9-1.md
2-2-1.md
14-c-1.md
4-a-1.md
5-6-1.md