### PR TITLE
switch to open-sdg and remove versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: python
 python:
   - "3.6"
-env:
-  - SDG_REF="master" API_VERSION=""
-  - SDG_REF="develop" API_VERSION="dev"
-#  - SDG_REF="hotfix/25" API_VERSION="test"
-matrix:
-  allow_failures:
-    - env: SDG_REF="develop"
 sudo: false
 git:
   depth: false
@@ -18,7 +11,6 @@ branches:
   - develop
 install:
   - pip install -r scripts/requirements.txt
-  - pip install git+git://github.com/ONSdigital/sdg-build@${SDG_REF}
 before_script:
   - chmod +x ./scripts/*.py
   - chmod +x ./scripts/deploy/*.sh

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Loosely speaking with have: `/<datatype>/<id>.<format>` and support csv and json
 
 ## Versions
 
-We're planning for versioned APIs. Right now the root location is the latest API. Other versions will be available. For example the development branch of the API code will be available by adding `dev` to the beginning of the path. e.g. `/dev/<datatype>/<id>.<format>`.
+We don't currently support API versioning.
 
 ## Data
 

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -33,13 +33,7 @@ cd out
 git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 
-# Use the API_VERSION variable to put in the right place
-# unset or empty
-if [ -z "$API_VERSION" ]; then
-  OUTDIR="out"
-else
-  OUTDIR="out/$API_VERSION"
-fi
+OUTDIR="out"
 
 # Overwrite contents with _site
 mkdir -p $OUTDIR

--- a/scripts/deploy/deploy_staging.sh
+++ b/scripts/deploy/deploy_staging.sh
@@ -34,14 +34,7 @@ cd out
 git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 
-
-# Use the API_VERSION variable to put in the right place
-# unset or empty
-if [ -z "$API_VERSION" ]; then
-  OUTDIR="out"
-else
-  OUTDIR="out/$API_VERSION"
-fi
+OUTDIR="out"
 
 # Overwrite contents with _site
 mkdir -p $OUTDIR

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,3 +3,4 @@ pandas
 gitpython
 ruamel.yaml>=0.15
 git+git://github.com/dougmet/yamlmd
+git+git://github.com/open-sdg/sdg-build@0.1.0


### PR DESCRIPTION
Fixes #483. Initially to version 0.1.0 fixes #11

Remove the build matrix of SDG_REF and API_VERSION. This is very travis
specific and out of scope. We can reimplement down the line if required.