### PR TITLE
17.1.1 metadata update

### DIFF
--- a/meta/17-1-1.md
+++ b/meta/17-1-1.md
@@ -9,46 +9,45 @@ indicator: 17.1.1
 title: >-
   Total government revenue as a proportion of GDP, by source
 indicator_name: 17.1.1 Total government revenue as a proportion of GDP, by source
-national_indicator_available: Total government revenue as a percentage of GDP, by source
+national_indicator_available: General government revenue as a percentage of GDP, by source
 un_designated_tier: 1.0
 un_custodian_agency: International Monetary Fund (IMF)
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469 KB)
-national_geographical_coverage: United Kingdom
+national_geographical_coverage: United Kingdom general government revenue
 computation_units: Percentage (%)
 computation_definitions: >-
-  In the OECD classification the term “taxes” is defined as compulsory unrequited payments to general government. The definition of government follows that of the 2008 System of National Accounts (SNA). As disagregations of general government, central government here refers to the
-  government of the United Kingdom and local government refers, collectively, to the administration of counties or districts, with representatives elected by those who live there.
-computation_calculations: (Central, Local or Total government revenue / GDP) * 100
+  In the OECD classification the term “taxes” is defined as compulsory unrequited payments to general government. The definition of government follows that of the 2008 System of National Accounts (SNA). As disaggregations of general government, central government here refers to the
+  Government of the United Kingdom and local government refers, collectively, to the administration of counties or districts, with representatives elected by those who live there.
+computation_calculations: (Central, local or general government revenue / GDP) * 100
 reporting_status: complete
 data_non_statistical: false
 graph_type: line
-graph_title: Total government revenue as a percentage of GDP, by source
+graph_title: General government revenue as a percentage of GDP, by source
 data_show_map: false
 data_keywords: GDP
 source_active_1: true
 source_organisation_1: Office for National Statistics (ONS)
-source_periodicity_1: Quarterly
-source_earliest_available_1: 1990
+source_periodicity_1: Annually
+source_earliest_available_1: 1948
 source_geographical_coverage_1: United Kingdom
-source_url_1: https://www.ons.gov.uk/economy/governmentpublicsectorandtaxes/publicsectorfinance/datasets/publicsectorfinancesappendixatables110
-source_url_text_1: Public sector finances tables 1 to 10 - Appendix A
-source_release_date_1: 21/11/2018
-source_next_release_1: 21/12/2018
+source_url_1: www.ons.gov.uk/economy/grossdomesticproductgdp/datasets/bluebook
+source_url_text_1: UK National Accounts, The Blue Book time series 
+source_release_date_1: 30/07/2018
+source_next_release_1: To be announced
 source_statistical_classification_1: National Statistic
-source_contact_1: fraser.munro@ons.gsi.gov.uk
+source_contact_1: blue.book.coordination@ons.gov.uk  
 source_active_2: true
 source_organisation_2: Office for National Statistics (ONS)
-source_periodicity_2: Quarterly
-source_earliest_available_2: 1955
+source_periodicity_2: Annually
+source_earliest_available_2: 1946
 source_geographical_coverage_2: United Kingdom
-source_url_2: https://www.ons.gov.uk/economy/grossdomesticproductgdp
-source_url_text_2: Gross Domestic Product (GDP)
-source_release_date_2: 09/11/2018
-source_next_release_2: 21/12/2018
-source_statistical_classification_2: Official Statistic
-source_contact_2: gdp@ons.gsi.gov.uk 
-
+source_url_2: www.ons.gov.uk/economy/governmentpublicsectorandtaxes/publicsectorfinance/datasets/publicsectorfinances
+source_url_text_2: Public sector finances time series
+source_release_date_2: 22/01/2019
+source_next_release_2: 21/02/2019
+source_statistical_classification_2: National Statistic
+source_contact_2: fraser.munro@ons.gov.uk
 source_active_3: false
 source_active_4: false
 source_active_5: false


### PR DESCRIPTION
Addition of 'revenue' title to Uk coverage and change to the term General Government rather than UK government for totals (as per advice of topic expert)