### PR TITLE
bump to sdg-build 0.2.1

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,4 +3,4 @@ pandas
 gitpython
 ruamel.yaml>=0.15
 git+git://github.com/dougmet/yamlmd
-git+git://github.com/open-sdg/sdg-build@0.1.0
+git+git://github.com/open-sdg/sdg-build@0.2.1


### PR DESCRIPTION
Brings in an important fix to `edges/<ID>.json` which was being overwritten.