### PR TITLE
Use rsync to deploy

### DIFF
--- a/scripts/deploy/deploy_testing.sh
+++ b/scripts/deploy/deploy_testing.sh
@@ -23,8 +23,8 @@ rm scripts/deploy/keys.tar
 chmod 600 ./scripts/deploy/deploy_key_test
 eval `ssh-agent -s`
 ssh-add scripts/deploy/deploy_key_test
-rm scripts/deploy/deploy_key*
+#rm scripts/deploy/deploy_key*
 
 # Push the files over, removing anything existing already.
 ssh -oStrictHostKeyChecking=no travis@$TEST_SERVER "rm -rf ~/www/data/$BASEURL || true"
-scp -oStrictHostKeyChecking=no -rC _site travis@$TEST_SERVER:~/www/data/$BASEURL
+rsync -avz -e "ssh -i scripts/deploy/deploy_key_test -oStrictHostKeyChecking=no" --link-dest="../sdg-indicators" _site/ travis@$TEST_SERVER:~/www/data/$BASEURL

--- a/scripts/deploy/deploy_testing.sh
+++ b/scripts/deploy/deploy_testing.sh
@@ -27,4 +27,4 @@ ssh-add scripts/deploy/deploy_key_test
 
 # Push the files over, removing anything existing already.
 ssh -oStrictHostKeyChecking=no travis@$TEST_SERVER "rm -rf ~/www/data/$BASEURL || true"
-rsync -avz -e "ssh -i scripts/deploy/deploy_key_test -oStrictHostKeyChecking=no" --ignore-times --link-dest="../sdg-indicators" _site/ travis@$TEST_SERVER:~/www/data/$BASEURL
+rsync -rvz -e "ssh -i scripts/deploy/deploy_key_test -oStrictHostKeyChecking=no" --checksum --link-dest="../sdg-indicators" _site/ travis@$TEST_SERVER:~/www/data/$BASEURL

--- a/scripts/deploy/deploy_testing.sh
+++ b/scripts/deploy/deploy_testing.sh
@@ -23,8 +23,8 @@ rm scripts/deploy/keys.tar
 chmod 600 ./scripts/deploy/deploy_key_test
 eval `ssh-agent -s`
 ssh-add scripts/deploy/deploy_key_test
-#rm scripts/deploy/deploy_key*
 
 # Push the files over, removing anything existing already.
 ssh -oStrictHostKeyChecking=no travis@$TEST_SERVER "rm -rf ~/www/data/$BASEURL || true"
-rsync -rvz -e "ssh -i scripts/deploy/deploy_key_test -oStrictHostKeyChecking=no" --checksum --link-dest="../sdg-indicators" _site/ travis@$TEST_SERVER:~/www/data/$BASEURL
+rsync -rvz -e "ssh -i scripts/deploy/deploy_key_test -oStrictHostKeyChecking=no" --checksum --link-dest="../develop" _site/ travis@$TEST_SERVER:~/www/data/$BASEURL
+rm scripts/deploy/deploy_key*

--- a/scripts/deploy/deploy_testing.sh
+++ b/scripts/deploy/deploy_testing.sh
@@ -27,4 +27,4 @@ ssh-add scripts/deploy/deploy_key_test
 
 # Push the files over, removing anything existing already.
 ssh -oStrictHostKeyChecking=no travis@$TEST_SERVER "rm -rf ~/www/data/$BASEURL || true"
-rsync -avz -e "ssh -i scripts/deploy/deploy_key_test -oStrictHostKeyChecking=no" --link-dest="../sdg-indicators" _site/ travis@$TEST_SERVER:~/www/data/$BASEURL
+rsync -avz -e "ssh -i scripts/deploy/deploy_key_test -oStrictHostKeyChecking=no" --ignore-times --link-dest="../sdg-indicators" _site/ travis@$TEST_SERVER:~/www/data/$BASEURL

--- a/scripts/deploy/deploy_testing.sh
+++ b/scripts/deploy/deploy_testing.sh
@@ -21,10 +21,8 @@ tar xvf scripts/deploy/keys.tar -C scripts/deploy/
 rm scripts/deploy/keys.tar
 
 chmod 600 ./scripts/deploy/deploy_key_test
-eval `ssh-agent -s`
-ssh-add scripts/deploy/deploy_key_test
 
 # Push the files over, removing anything existing already.
 ssh -oStrictHostKeyChecking=no travis@$TEST_SERVER "rm -rf ~/www/data/$BASEURL || true"
-rsync -rvz -e "ssh -i scripts/deploy/deploy_key_test -oStrictHostKeyChecking=no" --checksum --link-dest="../develop" _site/ travis@$TEST_SERVER:~/www/data/$BASEURL
+rsync -rvzh -e "ssh -i scripts/deploy/deploy_key_test -oStrictHostKeyChecking=no" --checksum --link-dest="../develop" _site/ travis@$TEST_SERVER:~/www/data/$BASEURL
 rm scripts/deploy/deploy_key*

--- a/scripts/deploy/deploy_testing.sh
+++ b/scripts/deploy/deploy_testing.sh
@@ -21,6 +21,8 @@ tar xvf scripts/deploy/keys.tar -C scripts/deploy/
 rm scripts/deploy/keys.tar
 
 chmod 600 ./scripts/deploy/deploy_key_test
+eval `ssh-agent -s`
+ssh-add scripts/deploy/deploy_key_test
 
 # Push the files over, removing anything existing already.
 ssh -oStrictHostKeyChecking=no travis@$TEST_SERVER "rm -rf ~/www/data/$BASEURL || true"


### PR DESCRIPTION
Even without incremental updates rsync is loads quicker than ssh. 

This attempts to compare changes against the current `develop` branch and only copy changes. Files that are the same are "hard linked" to develop, which means that they don't occupy any extra space either. 

Initial testing show it's a lot quicker.