### PR TITLE
upgrade to sdg-build 0.3.1

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,4 +3,4 @@ pandas
 gitpython
 ruamel.yaml>=0.15
 git+git://github.com/dougmet/yamlmd
-git+git://github.com/open-sdg/sdg-build@0.3.0
+git+git://github.com/open-sdg/sdg-build@0.3.1


### PR DESCRIPTION
ignores SDMX columns as edges. Shouldn't change anything else.