### PR TITLE
footnote fix

### DIFF
--- a/meta/7-b-1.md
+++ b/meta/7-b-1.md
@@ -22,8 +22,8 @@ computation_definitions: IEA - International Energy Agency
 reporting_status: complete
 data_non_statistical: false
 data_footnote: >-
-  Indicator 7.b.1 is in two parts. Part 1 of the indicator (“Investments in energy efficiency as a proportion of GDP...") is currently displaying, and we are in the process of sourcing Part 2 ("...the amount of foreign direct investment in financial transfer for infrastructure and
-  technology to sustainable development services”). FDI data disaggregated by ‘sustainability development services’ (or similar) are not currently available, and UN Stat (1) recommend further 'reflections on definition' to inform data acquisition for this indicator.
+  Indicator 7.b.1 is in two parts. Part 1 of the indicator ("Investments in energy efficiency as a proportion of GDP...") is currently displaying, and we are in the process of sourcing Part 2 ("...the amount of foreign direct investment in financial transfer for infrastructure and
+  technology to sustainable development services"). FDI data disaggregated by ‘sustainability development services’ (or similar) are not currently available, and UN Stat (1) recommend further 'reflections on definition' to inform data acquisition for this indicator.
   
   (1) -
   https://unstats.un.org/sdgs/files/meetings/iaeg-sdgs-meeting-03/3rd-IAEG-SDGs-presentation-SE4ALL--7.b.1.pdf


### PR DESCRIPTION
Footnote seems to be cut off. Think it's due to the different speech marks used:
![image](https://user-images.githubusercontent.com/43404358/64427518-48be6b00-d0a9-11e9-8f77-888b9723167f.png)
