### PR TITLE
10-a-1 change to headline

### DIFF
--- a/data/indicator_10-a-1.csv
+++ b/data/indicator_10-a-1.csv
@@ -1,19 +1,19 @@
 Year,Country Group,Product Sector,Value
-2005,Developing,Overall,43.0508047384
-2006,Developing,Overall,43.00242385920539
-2007,Developing,Overall,41.02660938803128
-2008,Developing,Overall,41.88083249963098
-2009,Developing,Overall,42.05498017300517
-2010,Developing,Overall,42.61787312148675
-2011,Developing,Overall,43.0338519108832
-2012,Developing,Overall,42.65996845209519
-2013,Developing,Overall,42.810601967814286
-2014,Developing,Overall,43.310456064122185
-2015,Developing,Overall,43.50717014836501
-2016,Developing,Overall,45.260405670948565
-2017,Developing,Overall,45.8966565349544
-2018,Developing,Overall,46.95576436694974
-2019,Developing,Overall,47.67470172875578
+2005,Developing,,43.0508047384
+2006,Developing,,43.00242385920539
+2007,Developing,,41.02660938803128
+2008,Developing,,41.88083249963098
+2009,Developing,,42.05498017300517
+2010,Developing,,42.61787312148675
+2011,Developing,,43.0338519108832
+2012,Developing,,42.65996845209519
+2013,Developing,,42.810601967814286
+2014,Developing,,43.310456064122185
+2015,Developing,,43.50717014836501
+2016,Developing,,45.260405670948565
+2017,Developing,,45.8966565349544
+2018,Developing,,46.95576436694974
+2019,Developing,,47.67470172875578
 2005,Developing,AGRI,46.864197530864196
 2006,Developing,AGRI,47.39347774339443
 2007,Developing,AGRI,46.79541595925297
@@ -74,21 +74,21 @@ Year,Country Group,Product Sector,Value
 2017,Developing,PAPS,44.81651376146789
 2018,Developing,PAPS,47.59309718437784
 2019,Developing,PAPS,46.902654867256636
-2005,Least Developed,Overall,56.516443361754
-2006,Least Developed,Overall,56.485484867201976
-2007,Least Developed,Overall,51.14709851551957
-2008,Least Developed,Overall,56.94643368662275
-2009,Least Developed,Overall,58.139534883720934
-2010,Least Developed,Overall,60.77818801476853
-2011,Least Developed,Overall,62.559665871121716
-2012,Least Developed,Overall,64.71647164716472
-2013,Least Developed,Overall,63.9497594869054
-2014,Least Developed,Overall,65.23821527602722
-2015,Least Developed,Overall,63.472622478386164
-2016,Least Developed,Overall,63.732718894009224
-2017,Least Developed,Overall,63.15913927642469
-2018,Least Developed,Overall,63.46153846153846
-2019,Least Developed,Overall,63.87981711299804
+2005,Least Developed,,56.516443361754
+2006,Least Developed,,56.485484867201976
+2007,Least Developed,,51.14709851551957
+2008,Least Developed,,56.94643368662275
+2009,Least Developed,,58.139534883720934
+2010,Least Developed,,60.77818801476853
+2011,Least Developed,,62.559665871121716
+2012,Least Developed,,64.71647164716472
+2013,Least Developed,,63.9497594869054
+2014,Least Developed,,65.23821527602722
+2015,Least Developed,,63.472622478386164
+2016,Least Developed,,63.732718894009224
+2017,Least Developed,,63.15913927642469
+2018,Least Developed,,63.46153846153846
+2019,Least Developed,,63.87981711299804
 2005,Least Developed,AGRI,79.1095890410959
 2006,Least Developed,AGRI,80.54607508532423
 2007,Least Developed,AGRI,71.97802197802197
@@ -149,21 +149,21 @@ Year,Country Group,Product Sector,Value
 2017,Least Developed,PAPS,83.78378378378379
 2018,Least Developed,PAPS,88.59649122807018
 2019,Least Developed,PAPS,84.61538461538461
-2005,Small Island Developing,Overall,51.515151515151516
-2006,Small Island Developing,Overall,51.668984700973574
-2007,Small Island Developing,Overall,51.14709851551957
-2008,Small Island Developing,Overall,58.620689655172406
-2009,Small Island Developing,Overall,60.150375939849624
-2010,Small Island Developing,Overall,59.67617579028527
-2011,Small Island Developing,Overall,63.412563667232604
-2012,Small Island Developing,Overall,58.996815286624205
-2013,Small Island Developing,Overall,58.99104963384866
-2014,Small Island Developing,Overall,60.129136400322835
-2015,Small Island Developing,Overall,59.131134352373294
-2016,Small Island Developing,Overall,57.63358778625955
-2017,Small Island Developing,Overall,56.059532246633594
-2018,Small Island Developing,Overall,59.6958174904943
-2019,Small Island Developing,Overall,59.86696230598669
+2005,Small Island Developing,,51.515151515151516
+2006,Small Island Developing,,51.668984700973574
+2007,Small Island Developing,,51.14709851551957
+2008,Small Island Developing,,58.620689655172406
+2009,Small Island Developing,,60.150375939849624
+2010,Small Island Developing,,59.67617579028527
+2011,Small Island Developing,,63.412563667232604
+2012,Small Island Developing,,58.996815286624205
+2013,Small Island Developing,,58.99104963384866
+2014,Small Island Developing,,60.129136400322835
+2015,Small Island Developing,,59.131134352373294
+2016,Small Island Developing,,57.63358778625955
+2017,Small Island Developing,,56.059532246633594
+2018,Small Island Developing,,59.6958174904943
+2019,Small Island Developing,,59.86696230598669
 2005,Small Island Developing,AGRI,72.36842105263158
 2006,Small Island Developing,AGRI,71.03825136612022
 2007,Small Island Developing,AGRI,71.97802197802197


### PR DESCRIPTION
Removed the "overall" label, so that the value is picked up as headline, and the rest are disaggregations into product sectors.